### PR TITLE
🛡️ Sentinel: [HIGH] Fix vulnerabilities in MiqAction

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,9 @@
+## 2025-05-14 - [Unsafe method invocation in template substitution]
+**Vulnerability:** Unrestricted use of `send(method)` where `method` is derived from user-configurable template variables (e.g., in SNMP trap options).
+**Learning:** The application allowed arbitrary method calls on model instances through `${Object.method}` syntax in policy actions. This could be exploited to trigger side-effect heavy methods like `destroy`.
+**Prevention:** Always use an allowlist of safe attributes and virtual columns when dynamically invoking methods on objects from user-supplied strings. Use `public_send` instead of `send`.
+
+## 2025-05-14 - [Misuse of manual quoting in non-shell command execution]
+**Vulnerability:** Manual interpolation of single quotes around arguments passed to `Open3.capture3` with multiple arguments.
+**Learning:** Developers often mistakenly add quotes to arguments thinking they are protecting against shell injection, even when using APIs that do not invoke a shell. This actually causes the literal quotes to be passed as part of the argument value, which can then cause downstream injection if the receiving script uses the argument unsafely.
+**Prevention:** Trust the OS/API to handle argument separation when using non-shell execution methods. Pass arguments as separate elements in an array or argument list without manual quoting.

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -95,9 +95,9 @@ class MiqAction < ActiveRecord::Base
     when "snapshot_create"
       errors.add("snapshot_create", "no snapshot name provided") unless self.options && self.options[:name]
     when "reconfigure_cpus"
-      errors.add("reconfigure_cpus", "CPUs valie must be 1, 2 or 4") unless self.options && [1, 2, 4].include?(self.options[:value].to_i)
+      errors.add("reconfigure_cpus", "CPUs value must be 1, 2 or 4") unless self.options && [1, 2, 4].include?(self.options[:value].to_i)
     when "reconfigure_memory"
-      errors.add("reconfigure_cpus", "Memory value must be between 4 and 65,536") unless self.options && self.options[:value].to_i >= 4 && self.options[:value].to_i <= 65536
+      errors.add("reconfigure_memory", "Memory value must be between 4 and 65,536") unless self.options && self.options[:value].to_i >= 4 && self.options[:value].to_i <= 65536
     end
   end
 
@@ -267,7 +267,13 @@ class MiqAction < ActiveRecord::Base
             ems = rec.ext_management_system
             subst = "vCenter #{ems.hostname}/#{ems.ipaddress}" unless ems.nil?
           elsif rec.respond_to?(method)
-            subst = rec.send(method)
+            # Only allow calling methods that are likely safe getters to prevent
+            # unintended method invocation of dangerous methods like 'destroy'.
+            if (rec.class.respond_to?(:attribute_names) && rec.class.attribute_names.include?(method)) ||
+               method.start_with?('v_') ||
+               %w(name hostname ipaddress).include?(method)
+              subst = rec.public_send(method)
+            end
           end
         end
 
@@ -480,8 +486,8 @@ class MiqAction < ActiveRecord::Base
     MiqPolicy.logger.info("MIQ(action_script): Executing: [#{filename}]")
     if File.extname(filename) == ".rb"
       rails_cmd = MiqEnvironment::Command.rails_command
-      MiqPolicy.logger.info("MIQ(action_script): Eval:      [#{rails_cmd} runner #{fname} '#{rec.name}'}]")
-      result, _, status = Open3.capture3(rails_cmd, "runner", fname, "'#{rec.name}'")
+      MiqPolicy.logger.info("MIQ(action_script): Eval:      [#{rails_cmd} runner #{fname} #{rec.name}]")
+      result, _, status = Open3.capture3(rails_cmd, "runner", fname, rec.name)
     else
       MiqPolicy.logger.info("MIQ(action_script): Eval:      [#{fname}]")
       result, _, status = Open3.capture3(fname)


### PR DESCRIPTION
🛡️ Sentinel: Security Fixes in MiqAction

🚨 Severity: HIGH
💡 Vulnerabilities found:
1. Unrestricted Method Invocation: The `action_snmp_trap` method allowed calling arbitrary methods on model instances (e.g., `${Object.destroy}`) via template substitution.
2. Unsafe Script Arguments: The `run_script` method used manual single quotes around arguments passed to `Open3.capture3`. This caused literal quotes to be part of the argument, which can lead to command injection if the target script uses the argument unsafely.

🔧 Fix:
- Implemented an allowlist for SNMP trap substitution that only permits database attributes, virtual columns (starting with `v_`), and common safe getters (`name`, `hostname`, `ipaddress`).
- Switched to `public_send` for safer method invocation.
- Removed manual quoting in `Open3.capture3` calls, allowing the API to handle argument separation safely.
- Fixed typos and logic errors in `validate` method.

✅ Verification:
- Manual code inspection and syntax verification with `ruby -c`.
- Verified that `rec.name` is now passed without literal single quotes.
- Verified that arbitrary methods can no longer be called via SNMP trap options.

---
*PR created automatically by Jules for task [3332776107248314065](https://jules.google.com/task/3332776107248314065) started by @Fryguy*